### PR TITLE
Fix protocol initialization for ConsoleSample

### DIFF
--- a/ctrader_open_api/client.py
+++ b/ctrader_open_api/client.py
@@ -11,7 +11,7 @@ class Client(ClientService):
         self._runningReactor = reactor
         self.numberOfMessagesToSendPerSecond = numberOfMessagesToSendPerSecond
         endpoint = clientFromString(self._runningReactor, f"ssl:{host}:{port}")
-        factory = Factory(client=self)
+        factory = Factory.forProtocol(protocol, client=self)
         super().__init__(endpoint, factory, retryPolicy=retryPolicy, clock=clock, prepareConnection=prepareConnection)
         self._events = dict()
         self._responseDeferreds = dict()

--- a/ctrader_open_api/factory.py
+++ b/ctrader_open_api/factory.py
@@ -13,3 +13,13 @@ class Factory(ClientFactory):
         self.client._disconnected(reason)
     def received(self, message):
         self.client._received(message)
+
+    @staticmethod
+    def build_payload(message_cls, **params):
+        """Create and populate a protobuf message instance."""
+        msg = message_cls()
+        if 'accountId' in params and hasattr(msg, 'ctidTraderAccountId'):
+            setattr(msg, 'ctidTraderAccountId', params.pop('accountId'))
+        for field, value in params.items():
+            setattr(msg, field, value)
+        return msg

--- a/samples/ConsoleSample/main.py
+++ b/samples/ConsoleSample/main.py
@@ -3,6 +3,7 @@ import os
 from twisted.internet import reactor
 from ctrader_open_api.client import Client
 from ctrader_open_api.factory import Factory
+from ctrader_open_api import TcpProtocol
 from ctrader_open_api.messages.OpenApiMessages_pb2 import ProtoOAAccountAuthReq
 
 # Load credentials
@@ -16,7 +17,7 @@ connectionType = creds.get("connectionType", "Live").lower()
 
 host = "live.ctraderapi.com" if connectionType == "live" else "demo.ctraderapi.com"
 port = 5035
-protocol = "protobuf"
+protocol = TcpProtocol
 
 # Create client
 client = Client(host=host, port=port, protocol=protocol)


### PR DESCRIPTION
## Summary
- ensure `Client` initializes its factory with a protocol
- use `TcpProtocol` in the ConsoleSample example
- add `Factory.build_payload` helper for sample convenience

## Testing
- `python -m py_compile samples/ConsoleSample/main.py ctrader_open_api/client.py ctrader_open_api/factory.py`


------
https://chatgpt.com/codex/tasks/task_e_6849bc1edf5c8333a192dbd6e965d641