### PR TITLE
Fix tick visualizer refresh function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ pyOpenSSL = "24.1.0"
 protobuf = "3.20.1"
 requests = "2.32.3"
 inputimeout = "1.0.4"
+streamlit = "^1.34.0"
+streamlit-autorefresh = "^0.1.0"
 
 [tool.black]
 line-length=100

--- a/samples/ConsoleSample/tickVisualizer.py
+++ b/samples/ConsoleSample/tickVisualizer.py
@@ -3,6 +3,7 @@
 import os
 import pandas as pd
 import streamlit as st
+from streamlit_autorefresh import st_autorefresh
 
 csvFile = "ticks.csv"
 
@@ -12,17 +13,11 @@ st.title("📈 Live Tick Data Stream for GOLD")
 st.caption("Streaming from ticks.csv and updating in real time.")
 
 # Auto-refresh every 1000 ms (1 second)
-st.experimental_rerun
-st_autorefresh = st.experimental_rerun if hasattr(st, 'experimental_rerun') else None
-if hasattr(st, 'experimental_rerun'):
-    from streamlit_autorefresh import st_autorefresh
-
-# Trigger a rerun every 1 second
 st_autorefresh(interval=1000, limit=None, key="tick_autorefresh")
 
 # Load data
 if os.path.exists(csvFile):
     df = pd.read_csv(csvFile)
-    st.dataframe(df.tail(30), use_container_width=True)
+    st.data_editor(df.tail(30), use_container_width=True)
 else:
     st.warning("No data yet. Please wait for tick data to be generated.")


### PR DESCRIPTION
## Summary
- simplify auto refresh logic in tick visualizer
- ensure display uses `st.data_editor`
- add Streamlit dev dependencies for linting environments

## Testing
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_684b1832b17083339757ced9b477caba