### PR TITLE
Add wheel zoom data loading in tick stream

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ requests = "2.32.3"
 inputimeout = "1.0.4"
 streamlit = "^1.34.0"
 streamlit-autorefresh = "^0.1.0"
+streamlit-plotly-events = "^0.0.6"
 
 [tool.black]
 line-length=100


### PR DESCRIPTION
## Summary
- support zoom-based data loading in `tickStream.py`
- remove manual navigation buttons
- add `streamlit-plotly-events` to dev requirements

## Testing
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_684cb7fa8c008333826937f5d496576e