### PR TITLE
Enable wheel-based zoom with dynamic history

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ requests = "2.32.3"
 inputimeout = "1.0.4"
 streamlit = "^1.34.0"
 streamlit-autorefresh = "^0.1.0"
+streamlit-plotly-events = "^0.0.6"
 
 [tool.black]
 line-length=100

--- a/tickStream.py
+++ b/tickStream.py
@@ -4,6 +4,11 @@ import streamlit as st
 import plotly.graph_objects as go
 from streamlit_autorefresh import st_autorefresh
 
+try:
+    from streamlit_plotly_events import plotly_events
+except ModuleNotFoundError:
+    plotly_events = None
+
 # Streamlit UI setup (must be first)
 st.set_page_config(page_title="Gold Live Stream", layout="wide")
 st_autorefresh(interval=1000, key="auto_refresh")
@@ -13,68 +18,70 @@ st.caption("Streaming XAUUSD data directly from database")
 
 # PostgreSQL connection configuration
 conn = psycopg2.connect(
-    dbname="trading",
-    user="babak",
-    password="BB@bb33044",
-    host="localhost",
-    port=5432
+    dbname="trading", user="babak", password="BB@bb33044", host="localhost", port=5432
 )
 
-# Initialize session state to manage loaded range
-if "start_index" not in st.session_state:
-    st.session_state.start_index = -550  # Load 500 + 10% buffer initially
+# Manage session state for how many rows to load
+WINDOW = 500
+if "rows_loaded" not in st.session_state:
+    st.session_state.rows_loaded = WINDOW
 
-# Count total rows
+# Determine total number of rows
 with conn.cursor() as cur:
     cur.execute("SELECT COUNT(*) FROM ticks WHERE symbol = 'XAUUSD'")
     total_rows = cur.fetchone()[0]
 
-# Query the window with a 10% buffer
-window_size = 500
-buffer = int(window_size * 0.1)
-start = max(total_rows + st.session_state.start_index, 0)
-limit = window_size + buffer
 
-query = f"""
-    SELECT timestamp, bid, ask
-    FROM ticks
-    WHERE symbol = 'XAUUSD'
-    ORDER BY id
-    OFFSET {start}
-    LIMIT {limit}
-"""
+def load_rows(num_rows: int) -> pd.DataFrame:
+    start = max(total_rows - num_rows, 0)
+    query = f"""
+        SELECT timestamp, bid, ask
+        FROM ticks
+        WHERE symbol = 'XAUUSD'
+        ORDER BY id
+        OFFSET {start}
+        LIMIT {num_rows}
+    """
+    return pd.read_sql(query, conn)
 
-# Load and process data
-df = pd.read_sql(query, conn)
+
+# Load current window
+df = load_rows(st.session_state.rows_loaded)
 conn.close()
 
 if df.empty:
     st.warning("No tick data found.")
 else:
     df = df.sort_values("timestamp")
-    df["timestamp"] = df["timestamp"].dt.strftime('%H:%M:%S')
 
     fig = go.Figure()
-    fig.add_trace(go.Scatter(x=df["timestamp"], y=df["bid"], mode='lines', name="bid"))
-    fig.add_trace(go.Scatter(x=df["timestamp"], y=df["ask"], mode='lines', name="ask"))
+    fig.add_trace(go.Scatter(x=df["timestamp"], y=df["bid"], mode="lines", name="bid"))
+    fig.add_trace(go.Scatter(x=df["timestamp"], y=df["ask"], mode="lines", name="ask"))
+
+    start_idx = max(len(df) - WINDOW, 0)
 
     fig.update_layout(
         xaxis_title="Time",
         yaxis_title="Price",
         xaxis_rangeslider_visible=True,
+        xaxis_range=[df["timestamp"].iloc[start_idx], df["timestamp"].iloc[-1]],
         height=600,
-        uirevision="window",
+        uirevision="stream",
     )
 
-    st.plotly_chart(fig, use_container_width=True)
-
-    # Dynamic data loading logic (future)
-    # You could attach JavaScript or Streamlit events to load more on zoom/pan
-    # For now, session state can be manipulated manually:
-    if st.button("⬅️ Load More Left"):
-        st.session_state.start_index -= int(window_size * 0.1)
-        st.experimental_rerun()
-
-    if st.button("🔄 Reset View"):
-        st.session_state.start_index = -550
-        st.experimental_rerun()
+    if plotly_events:
+        events = plotly_events(
+            fig,
+            events=["relayout"],
+            key="tick_chart",
+            config={"scrollZoom": True},
+        )
+        if events and "xaxis.range[0]" in events[0]:
+            range_start = pd.to_datetime(events[0]["xaxis.range[0]"])
+            earliest = df["timestamp"].iloc[0]
+            if range_start < earliest and st.session_state.rows_loaded < total_rows:
+                st.session_state.rows_loaded = min(st.session_state.rows_loaded * 2, total_rows)
+                st.experimental_rerun()
+    else:
+        st.warning("streamlit-plotly-events not installed, zoom-based loading disabled")
+        st.plotly_chart(fig, use_container_width=True, config={"scrollZoom": True})


### PR DESCRIPTION
## Summary
- include `streamlit-plotly-events` so zoom events are handled
- stream ticks with wheel zoom support and automatic loading

## Testing
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_684cb7fa8c008333826937f5d496576e